### PR TITLE
Parse table-based Lektiebog homework into per-subject items (fixes #7)

### DIFF
--- a/custom_components/foraeldreintra/api_parser.py
+++ b/custom_components/foraeldreintra/api_parser.py
@@ -209,22 +209,63 @@ def _parse_weekplan_page(
     }
 
 
+def _clean_text(txt: str) -> str:
+    return (txt or "").replace("\xa0", " ").strip()
+
+
+def _normalize_subject(s: str) -> str:
+    s = (s or "").strip().replace(":", "")
+    if not s:
+        return ""
+    return s.lower().capitalize()
+
+
+def _ensure_subject(s: str | None) -> str:
+    s2 = _normalize_subject(s or "")
+    return s2 if s2 else "Ukendt"
+
+
+def _parse_lektiebog_table_rows(table: Any, dato: str) -> list[dict[str, Any]]:
+    """Parser en 'Lektiebog'-tabel (FAG/LEKTIER-kolonner) til homework-items."""
+    items: list[dict[str, Any]] = []
+
+    for row in table.find_all("tr"):
+        cells = row.find_all(["td", "th"])
+        if len(cells) < 2:
+            continue
+
+        fag_cell, content_cell = cells[0], cells[1]
+        fag_text = _clean_text(fag_cell.get_text(" ", strip=True))
+
+        if fag_cell.name == "th" or fag_text.lower() in ("fag", "lektier"):
+            continue
+
+        links: list[dict[str, Any]] = []
+        for a in content_cell.find_all("a"):
+            t = _clean_text(a.get_text(strip=True)) or "link"
+            u = a.get("href")
+            links.append({"tekst": t, "url": u})
+            a.extract()
+
+        tekst = _clean_text(content_cell.get_text(" ", strip=True))
+        if not tekst and not links:
+            continue
+
+        items.append(
+            {
+                "dato": dato,
+                "fag": _ensure_subject(fag_text),
+                "tekst": tekst,
+                "links": links,
+            }
+        )
+
+    return items
+
+
 def _parse_homework_notes(html_text: str) -> list[dict[str, Any]]:
     soup = BeautifulSoup(html_text, "html.parser")
     result: list[dict[str, Any]] = []
-
-    def clean_text(txt: str) -> str:
-        return (txt or "").replace("\xa0", " ").strip()
-
-    def normalize_subject(s: str) -> str:
-        s = (s or "").strip().replace(":", "")
-        if not s:
-            return ""
-        return s.lower().capitalize()
-
-    def ensure_subject(s: str | None) -> str:
-        s2 = normalize_subject(s or "")
-        return s2 if s2 else "Ukendt"
 
     for li in soup.select("ul.sk-list > li"):
         dato_tag = li.select_one("div.sk-white-box > b")
@@ -234,6 +275,12 @@ def _parse_homework_notes(html_text: str) -> list[dict[str, Any]]:
             continue
 
         dato = dato_tag.get_text(strip=True).replace(":", "").strip()
+
+        table = content_div.find("table")
+        if table:
+            result.extend(_parse_lektiebog_table_rows(table, dato))
+            continue
+
         current_fag: str | None = None
         blocks: dict[str | None, dict[str, Any]] = {}
 
@@ -248,21 +295,21 @@ def _parse_homework_notes(html_text: str) -> list[dict[str, Any]]:
 
             strong = node.find("strong") if hasattr(node, "find") else None
             if strong:
-                fag_txt = normalize_subject(clean_text(strong.get_text(strip=True)))
+                fag_txt = _normalize_subject(_clean_text(strong.get_text(strip=True)))
                 if fag_txt:
                     current_fag = fag_txt
                     ensure_block(current_fag)
                 strong.extract()
 
             for a in node.find_all("a"):
-                t = clean_text(a.get_text(strip=True)) or "link"
+                t = _clean_text(a.get_text(strip=True)) or "link"
                 u = a.get("href")
                 ensure_block(current_fag)["links"].append(
                     {"tekst": t, "url": u}
                 )
                 a.extract()
 
-            txt = clean_text(node.get_text(" ", strip=True))
+            txt = _clean_text(node.get_text(" ", strip=True))
             if txt:
                 ensure_block(current_fag)["lines"].append(txt)
 
@@ -270,7 +317,7 @@ def _parse_homework_notes(html_text: str) -> list[dict[str, Any]]:
             lines = data.get("lines") or []
             links = data.get("links") or []
             tekst = "\n".join(
-                [clean_text(x) for x in lines if clean_text(x)]
+                [_clean_text(x) for x in lines if _clean_text(x)]
             ).strip()
 
             if not tekst and not links:
@@ -280,13 +327,13 @@ def _parse_homework_notes(html_text: str) -> list[dict[str, Any]]:
                 first_line = tekst.splitlines()[0].strip()
                 m = re.match(r"^([A-Za-zÆØÅæøå ]{2,30})\s*:\s*(.+)$", first_line)
                 if m:
-                    guessed_fag = normalize_subject(m.group(1).strip())
+                    guessed_fag = _normalize_subject(m.group(1).strip())
                     rest = m.group(2).strip()
                     fag = guessed_fag
                     remaining_lines = tekst.splitlines()[1:]
                     tekst = "\n".join([rest] + remaining_lines).strip()
 
-            fag_final = ensure_subject(str(fag) if fag is not None else None)
+            fag_final = _ensure_subject(str(fag) if fag is not None else None)
 
             result.append(
                 {

--- a/custom_components/foraeldreintra/manifest.json
+++ b/custom_components/foraeldreintra/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "foraeldreintra",
   "name": "ForældreIntra",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "documentation": "https://github.com/CagosDk/ha-foraeldreintra",
   "issue_tracker": "https://github.com/CagosDk/ha-foraeldreintra/issues",
   "codeowners": ["@CagosDk"],

--- a/tests/test_api_parsing.py
+++ b/tests/test_api_parsing.py
@@ -176,6 +176,71 @@ class TestParseHomeworkNotes:
         assert result[0]["links"][0]["tekst"] == "Klik her"
 
 
+class TestParseHomeworkNotesLektiebogTable:
+    def test_table_rows_split_into_separate_subjects(self):
+        html = """
+        <ul class="sk-list">
+          <li>
+            <div class="sk-white-box"><b>Onsdag, 15. apr. 2026:</b></div>
+            <div class="sk-user-input">
+              <table>
+                <tr><th>FAG</th><th>LEKTIER</th></tr>
+                <tr><td>DANSK</td><td>Læs side 100-103 i Kom og Læs</td></tr>
+                <tr><td>MATEMATIK</td><td>Lav side 38 færdig</td></tr>
+                <tr><td>ENGELSK</td><td></td></tr>
+                <tr><td>IDRÆT</td><td></td></tr>
+              </table>
+            </div>
+          </li>
+        </ul>
+        """
+        result = _parse_homework_notes(html)
+
+        assert len(result) == 2
+        assert result[0]["dato"] == "Onsdag, 15. apr. 2026"
+        assert result[0]["fag"] == "Dansk"
+        assert "Læs side 100-103" in result[0]["tekst"]
+        assert result[1]["fag"] == "Matematik"
+        assert "Lav side 38 færdig" in result[1]["tekst"]
+
+    def test_empty_subject_rows_are_skipped(self):
+        html = """
+        <ul class="sk-list">
+          <li>
+            <div class="sk-white-box"><b>15. apr. 2026:</b></div>
+            <div class="sk-user-input">
+              <table>
+                <tr><th>FAG</th><th>LEKTIER</th></tr>
+                <tr><td>ENGELSK</td><td></td></tr>
+                <tr><td>MUSIK</td><td>   </td></tr>
+              </table>
+            </div>
+          </li>
+        </ul>
+        """
+        assert _parse_homework_notes(html) == []
+
+    def test_table_links_are_extracted(self):
+        html = """
+        <ul class="sk-list">
+          <li>
+            <div class="sk-white-box"><b>15. apr. 2026:</b></div>
+            <div class="sk-user-input">
+              <table>
+                <tr><th>FAG</th><th>LEKTIER</th></tr>
+                <tr><td>DANSK</td><td><a href="https://example.com">Se opgave</a></td></tr>
+              </table>
+            </div>
+          </li>
+        </ul>
+        """
+        result = _parse_homework_notes(html)
+        assert len(result) == 1
+        assert result[0]["fag"] == "Dansk"
+        assert result[0]["links"][0]["url"] == "https://example.com"
+        assert result[0]["links"][0]["tekst"] == "Se opgave"
+
+
 class TestExtractLatestWeekplanFromList:
     def test_returns_none_for_html_without_container(self):
         assert _extract_latest_weekplan_from_list("<html></html>") is None


### PR DESCRIPTION
## Summary

Fixes #7.

Some schools render their "Lektiebog" (homework book) as an HTML `<table>` with **FAG** / **LEKTIER** columns — one row per subject — instead of the `<strong>`-tagged content blocks the existing parser expects. When the parser hits a `<table>`, it previously concatenated all cell text into a single block under "Ukendt", producing one long unstructured string in Home Assistant.

This PR detects a `<table>` inside `div.sk-user-input` and parses each row as a separate `(fag, tekst)` homework item:
- Header rows (`<th>` cells, or text "Fag"/"Lektier") are skipped
- Rows with empty content (e.g. subjects with no homework that day) are skipped
- Links inside the content cell are extracted as before

Internally, the small `clean_text`/`normalize_subject`/`ensure_subject` helpers were hoisted from nested functions to module level (`_clean_text`, `_normalize_subject`, `_ensure_subject`) so they can be shared between the table parser and the existing block parser.

## Test plan

- [x] `pytest tests/ -q` — 210 tests pass (3 new tests covering table parsing, empty-row skipping, and link extraction)
- [x] flake8 clean
- [ ] Verify against a real "Lektiebog" page from an affected school (reporter has confirmed the table structure via screenshot)

https://claude.ai/code/session_01242L1duUp443hqdMTgHPtD

---
_Generated by [Claude Code](https://claude.ai/code/session_01242L1duUp443hqdMTgHPtD)_